### PR TITLE
test: add omitHiddenProps utility tests

### DIFF
--- a/apps/fitdiary-api/src/utils/omit-hidden-props.spec.ts
+++ b/apps/fitdiary-api/src/utils/omit-hidden-props.spec.ts
@@ -1,0 +1,45 @@
+import { omitHiddenProps, Entities } from './omit-hidden-props';
+
+describe('omitHiddenProps', () => {
+  it('should omit hidden properties for Users entity', () => {
+    const user = {
+      id: '1',
+      username: 'test',
+      email: 'user@example.com',
+      password: 'secret',
+      scopes: ['admin'],
+      sessionId: 'session123',
+    };
+
+    const sanitized = omitHiddenProps(user, Entities.Users);
+
+    expect(sanitized).toEqual({
+      id: '1',
+      username: 'test',
+      email: 'user@example.com',
+    });
+  });
+
+  it('should return entity unchanged when no hidden properties present', () => {
+    const user = {
+      id: '2',
+      username: 'another',
+      email: 'another@example.com',
+    };
+
+    const sanitized = omitHiddenProps(user, Entities.Users);
+
+    expect(sanitized).toEqual(user);
+  });
+
+  it('should omit hidden properties for OtherEntity', () => {
+    const entity = {
+      visible: 'yes',
+      someHiddenField: 'secret',
+    };
+
+    const sanitized = omitHiddenProps(entity, Entities.OtherEntity);
+
+    expect(sanitized).toEqual({ visible: 'yes' });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for omitHiddenProps to ensure sensitive properties are filtered

## Testing
- `npm test --workspace=apps/fitdiary-api -- src/utils/omit-hidden-props.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fb19d4b388320b044511ed2dce07a